### PR TITLE
Implement builder daemon tick and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ strict_equality = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/accs_app"]
+
+[project.scripts]
+accs-builder = "accs_app.agents.builder:main"

--- a/src/accs_app/__init__.py
+++ b/src/accs_app/__init__.py
@@ -1,0 +1,1 @@
+"""ACCScore application package."""

--- a/src/accs_app/agents/__init__.py
+++ b/src/accs_app/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agent components for ACCS application."""

--- a/src/accs_app/agents/builder.py
+++ b/src/accs_app/agents/builder.py
@@ -1,0 +1,117 @@
+"""Builder daemon tick and CLI entry point."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DueJob:
+    """Identifier for a job that should be processed."""
+
+    job_id: str
+
+
+class Repo(Protocol):
+    """Repository facade used by :func:`tick` for persistence."""
+
+    def select_due_jobs(self, now: datetime) -> Iterable[DueJob]:
+        """Return jobs that are scheduled to run by ``now``."""
+
+    def instantiate_job_tasks(self, job_id: str) -> int:
+        """Instantiate tasks for the given job and return count of new tasks."""
+
+    def set_job_running_if_new_tasks(self, job_id: str, created: int) -> None:
+        """Mark the job running when new tasks were created."""
+
+    def apply_retry_backoff(self, now: datetime) -> int:
+        """Perform retry/backoff housekeeping and return number of jobs retried."""
+
+    def maybe_finish_job(self, job_id: str) -> bool:
+        """Attempt to finish job and return ``True`` if finished."""
+
+
+class DefaultRepo:
+    """Placeholder repository implementation to be wired to real storage."""
+
+    def select_due_jobs(self, now: datetime) -> Iterable[DueJob]:
+        """Return no jobs in the stub implementation."""
+        return ()
+
+    def instantiate_job_tasks(self, job_id: str) -> int:
+        """Return zero as no tasks are created."""
+        return 0
+
+    def set_job_running_if_new_tasks(self, job_id: str, created: int) -> None:
+        """No-op for stub implementation."""
+        return None
+
+    def apply_retry_backoff(self, now: datetime) -> int:
+        """Return zero as no retries are scheduled."""
+        return 0
+
+    def maybe_finish_job(self, job_id: str) -> bool:
+        """Return ``False`` to indicate unfinished job."""
+        return False
+
+
+def tick(repo: Repo | None = None, *, now: datetime | None = None) -> int:
+    """Execute one builder cycle.
+
+    The cycle performs the following actions:
+      * select due jobs (queued & scheduled_at <= now)
+      * instantiate tasks from workflow
+      * set job running if tasks were created
+      * apply retry/backoff pass
+      * attempt to finish jobs
+
+    Args:
+        repo: Repository implementation to use. Defaults to :class:`DefaultRepo`.
+        now: Current time. Defaults to ``datetime.now(UTC)``.
+
+    Returns:
+        Number of actions performed (jobs with created tasks + retries + finishes).
+    """
+    repo = repo or DefaultRepo()
+    now = now or datetime.now(UTC)
+
+    actions = 0
+    for due in repo.select_due_jobs(now):
+        created = repo.instantiate_job_tasks(due.job_id)
+        if created > 0:
+            repo.set_job_running_if_new_tasks(due.job_id, created)
+            actions += 1
+        if repo.maybe_finish_job(due.job_id):
+            actions += 1
+    actions += repo.apply_retry_backoff(now)
+    logger.info("tick actions=%s", actions)
+    return actions
+
+
+def main() -> None:
+    """Command line interface for the builder daemon."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--every", type=float, default=2.0, help="Seconds between ticks"
+    )
+    parser.add_argument(
+        "--once", action="store_true", help="Run a single tick and exit"
+    )
+    args = parser.parse_args()
+
+    repo: Repo = DefaultRepo()
+    if args.once:
+        tick(repo=repo)
+        return
+
+    while True:
+        tick(repo=repo)
+        time.sleep(args.every)

--- a/tests/test_builder_tick.py
+++ b/tests/test_builder_tick.py
@@ -1,0 +1,85 @@
+"""Tests for the builder tick loop and CLI."""
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+import pytest
+
+from accs_app.agents.builder import DueJob, Repo, main, tick
+
+
+class FakeRepo(Repo):
+    """In-memory repo used to observe builder interactions."""
+
+    def __init__(
+        self,
+        *,
+        due_jobs: list[str] | None = None,
+        instantiate: dict[str, int] | None = None,
+        retry: int = 0,
+        finish: bool = False,
+    ) -> None:
+        self.due_jobs = due_jobs or []
+        self.instantiate = instantiate or {}
+        self.retry = retry
+        self.finish = finish
+        self.instantiate_calls: list[str] = []
+        self.set_running_calls: list[tuple[str, int]] = []
+        self.retry_calls = 0
+        self.maybe_finish_calls: list[str] = []
+
+    def select_due_jobs(self, now: datetime) -> Iterable[DueJob]:
+        """Return configured due jobs."""
+        return [DueJob(job_id=j) for j in self.due_jobs]
+
+    def instantiate_job_tasks(self, job_id: str) -> int:
+        """Record call and return configured count."""
+        self.instantiate_calls.append(job_id)
+        return self.instantiate.get(job_id, 0)
+
+    def set_job_running_if_new_tasks(self, job_id: str, created: int) -> None:
+        """Record set-running calls."""
+        self.set_running_calls.append((job_id, created))
+
+    def apply_retry_backoff(self, now: datetime) -> int:
+        """Record retry pass and return configured count."""
+        self.retry_calls += 1
+        return self.retry
+
+    def maybe_finish_job(self, job_id: str) -> bool:
+        """Record finish attempts and return configured result."""
+        self.maybe_finish_calls.append(job_id)
+        return self.finish
+
+
+def test_instantiate_path() -> None:
+    """Instantiate tasks and mark job running."""
+    repo = FakeRepo(due_jobs=["job-1"], instantiate={"job-1": 2})
+    actions = tick(repo=repo, now=datetime(2024, 1, 1, tzinfo=UTC))
+    assert repo.set_running_calls == [("job-1", 2)]
+    assert repo.maybe_finish_calls == ["job-1"]
+    assert repo.retry_calls == 1
+    assert actions >= 1
+
+
+def test_no_due_jobs_only_retry() -> None:
+    """Return retry count when no jobs are due."""
+    repo = FakeRepo(retry=3)
+    actions = tick(repo=repo, now=datetime(2024, 1, 1, tzinfo=UTC))
+    assert repo.instantiate_calls == []
+    assert repo.set_running_calls == []
+    assert actions == 3
+
+
+def test_main_once_runs_single_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI `--once` triggers a single tick."""
+    ran = {"count": 0}
+
+    def fake_tick(repo: Repo | None = None, *, now: datetime | None = None) -> int:  # noqa: ARG001
+        ran["count"] += 1
+        return 0
+
+    monkeypatch.setattr("accs_app.agents.builder.tick", fake_tick)
+    monkeypatch.setattr("sys.argv", ["accs-builder", "--once"])
+    main()
+    assert ran["count"] == 1


### PR DESCRIPTION
## Summary
- add a repository protocol, default stub, and builder tick cycle
- wire a CLI (`accs-builder`) with optional `--once` and interval controls
- cover job instantiation, retry-only, and CLI smoke via tests

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`
- `accs-builder --once`


------
https://chatgpt.com/codex/tasks/task_e_68964d958508832b876ce3fd1494f196