### PR TITLE
Test builder CLI once and exception handling

### DIFF
--- a/src/accs_app/agents/builder.py
+++ b/src/accs_app/agents/builder.py
@@ -113,5 +113,8 @@ def main() -> None:
         return
 
     while True:
-        tick(repo=repo)
+        try:
+            tick(repo=repo)
+        except Exception:  # noqa: BLE001
+            logger.exception("tick failed")
         time.sleep(args.every)

--- a/tests/test_builder_tick.py
+++ b/tests/test_builder_tick.py
@@ -71,8 +71,8 @@ def test_no_due_jobs_only_retry() -> None:
     assert actions == 3
 
 
-def test_main_once_runs_single_tick(monkeypatch: pytest.MonkeyPatch) -> None:
-    """CLI `--once` triggers a single tick."""
+def test_cli_once_calls_tick_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--once`` runs exactly one tick."""
     ran = {"count": 0}
 
     def fake_tick(repo: Repo | None = None, *, now: datetime | None = None) -> int:  # noqa: ARG001
@@ -83,3 +83,36 @@ def test_main_once_runs_single_tick(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sys.argv", ["accs-builder", "--once"])
     main()
     assert ran["count"] == 1
+
+
+def test_cli_loop_catches_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loop retries after exceptions and logs them."""
+    from accs_app.agents import builder
+
+    calls = {"tick": 0, "logged": 0}
+
+    def fake_tick(repo: Repo | None = None, *, now: datetime | None = None) -> int:  # noqa: ARG001
+        calls["tick"] += 1
+        if calls["tick"] == 1:
+            raise RuntimeError("boom")
+        builder._stop = True  # type: ignore[attr-defined]
+        return 0
+
+    def fake_sleep(_seconds: float) -> None:  # noqa: ARG001
+        if getattr(builder, "_stop", False):
+            raise SystemExit
+
+    def fake_exception(*_args: object, **_kwargs: object) -> None:
+        calls["logged"] += 1
+
+    monkeypatch.setattr(builder, "tick", fake_tick)
+    monkeypatch.setattr(builder.time, "sleep", fake_sleep)
+    monkeypatch.setattr(builder.logger, "exception", fake_exception)
+    monkeypatch.setattr(builder, "_stop", False, raising=False)
+    monkeypatch.setattr("sys.argv", ["accs-builder", "--every", "0"])
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert calls["tick"] == 2
+    assert calls["logged"] == 1


### PR DESCRIPTION
## Summary
- add CLI test to ensure --once triggers exactly one tick
- add CLI loop test covering exception logging and retry
- log tick exceptions in builder daemon loop

## Testing
- `ruff format tests/test_builder_tick.py src/accs_app/agents/builder.py`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896524b5e68832bafb9fa0fb10f468d