### PR TITLE
Add pre-commit config with accscore protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: forbid-submodule-changes
+        name: Forbid changes under libs/accscore (read-only submodule)
+        entry: >
+          bash -c 'if git diff --cached --name-only | grep -q "^libs/accscore/"; then echo "ERROR: Do not modify the accscore submodule (libs/accscore) — it is read-only."; exit 1; fi'
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add project-level pre-commit with Ruff and read-only accscore hook

## Testing
- `ruff check .` *(fails: 119 errors)*
- `mypy .` *(fails: 22 errors)*
- `pytest`
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6896528c8d64832bb2c8e3e84aee140d