### PR TITLE
test: cover DefaultRepo wiring fallbacks

### DIFF
--- a/tests/test_builder_repo_wiring.py
+++ b/tests/test_builder_repo_wiring.py
@@ -1,95 +1,114 @@
-"""DefaultRepo wiring to ACCScore functions."""
+"""Test ``DefaultRepo`` calls ACCScore paths with fallbacks."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
-from accs_app.agents.builder import DefaultRepo, DueJob
+from accs_app.agents import builder
+from accs_app.agents.builder import DefaultRepo
 
 
-def test_select_due_jobs_wires_to_accscore(monkeypatch: pytest.MonkeyPatch) -> None:
-    """select_due_jobs resolves to the ACCScore path."""
-    repo = DefaultRepo()
-
-    def fake_resolve(path: str) -> object:
-        assert path == "accscore.db.jobs.select_due_jobs"
-
-        def stub(now: datetime) -> list[dict[str, str]]:  # noqa: ARG001
-            return [{"id": "job-1"}, {"id": "job-2"}]
-
-        return stub
-
-    monkeypatch.setattr(repo, "_resolve", fake_resolve)
-
-    jobs = list(repo.select_due_jobs(datetime(2024, 1, 1, tzinfo=UTC)))
-    assert jobs == [DueJob(job_id="job-1"), DueJob(job_id="job-2")]
-
-
-def test_instantiate_job_tasks_wires_to_accscore(
-    monkeypatch: pytest.MonkeyPatch,
+def _patch_resolve(
+    monkeypatch: pytest.MonkeyPatch, mapping: dict[str, Callable[..., Any] | Exception]
 ) -> None:
-    """instantiate_job_tasks delegates to ACCScore."""
-    monkeypatch.setenv("ACC_MINIO_ENDPOINT", "x")
-    monkeypatch.setenv("ACC_MINIO_ACCESS_KEY", "x")
-    monkeypatch.setenv("ACC_MINIO_SECRET_KEY", "x")
-    monkeypatch.setenv("ACC_DB_URL", "sqlite://")
-    from accscore.db import jobs as jobs_mod  # type: ignore[import-not-found]
+    """Patch ``builder._resolve`` to return stubs or raise per ``mapping``."""
 
-    def stub(job_id: str) -> int:
-        assert job_id == "job-1"
+    def fake_resolve(path: str) -> Any:
+        result = mapping.get(path)
+        if isinstance(result, Exception):
+            raise result
+        if result is None:
+            raise RuntimeError(path)
+        return result
+
+    monkeypatch.setattr(builder, "_resolve", fake_resolve)
+    monkeypatch.setattr(builder.DefaultRepo, "_resolve", staticmethod(fake_resolve))
+
+
+def test_select_due_jobs_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Primary path returns job identifiers from heterogeneous rows."""
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+
+    def stub(now_param: datetime) -> list[Any]:  # noqa: ARG001
+        return [{"id": "j1"}, {"job_id": "j2"}, "j3"]
+
+    _patch_resolve(monkeypatch, {"accscore.db.jobs.select_due_jobs": stub})
+    repo = DefaultRepo()
+    ids = [d.job_id for d in repo.select_due_jobs(now)]
+    assert ids == ["j1", "j2", "j3"]
+
+
+def test_select_due_jobs_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falls back to alternate path when primary resolution fails."""
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+
+    def stub(now_param: datetime) -> list[Any]:  # noqa: ARG001
+        return [{"id": "j1"}, {"job_id": "j2"}, "j3"]
+
+    _patch_resolve(
+        monkeypatch,
+        {
+            "accscore.db.jobs.select_due_jobs": RuntimeError(),
+            "accscore.db.select_due_jobs": stub,
+        },
+    )
+    repo = DefaultRepo()
+    ids = [d.job_id for d in repo.select_due_jobs(now)]
+    assert ids == ["j1", "j2", "j3"]
+
+
+def test_instantiate_job_tasks_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """instantiate_job_tasks falls back to alternate path."""
+
+    def stub(job_id: str) -> int:  # noqa: ARG001
         return 2
 
-    monkeypatch.setattr(jobs_mod, "instantiate_job_tasks", stub)
+    _patch_resolve(
+        monkeypatch,
+        {
+            "accscore.db.jobs.instantiate_job_tasks": RuntimeError(),
+            "accscore.db.instantiate_tasks": stub,
+        },
+    )
     repo = DefaultRepo()
     assert repo.instantiate_job_tasks("job-1") == 2
 
 
-def test_set_job_running_if_new_tasks_noop_when_zero(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """set_job_running_if_new_tasks does nothing when no tasks created."""
-    repo = DefaultRepo()
-    calls = {"count": 0}
-
-    def fake_resolve(path: str) -> object:  # noqa: ARG001
-        calls["count"] += 1
-        return lambda *args, **kwargs: None
-
-    monkeypatch.setattr(repo, "_resolve", fake_resolve)
-    repo.set_job_running_if_new_tasks("job-1", 0)
-    assert calls["count"] == 0
-
-
-def test_apply_retry_backoff_returns_zero_when_missing(
+def test_apply_retry_backoff_missing(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """apply_retry_backoff yields zero and logs when function missing."""
+    """Returns zero and logs when both helper paths are missing."""
+    _patch_resolve(
+        monkeypatch,
+        {
+            "accscore.db.tasks.apply_retry_backoff": RuntimeError(),
+            "accscore.db.jobs.apply_retry_backoff": RuntimeError(),
+        },
+    )
     repo = DefaultRepo()
-
-    def fake_resolve(path: str) -> object:  # noqa: ARG001
-        raise KeyError
-
-    monkeypatch.setattr(repo, "_resolve", fake_resolve)
     caplog.set_level(logging.INFO)
-    assert repo.apply_retry_backoff(datetime(2024, 1, 1, tzinfo=UTC)) == 0
-    assert any("apply_retry_backoff" in rec.message for rec in caplog.records)
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    assert repo.apply_retry_backoff(now) == 0
+    assert any("apply_retry_backoff.missing" in rec.message for rec in caplog.records)
 
 
-def test_maybe_finish_job_wires(monkeypatch: pytest.MonkeyPatch) -> None:
-    """maybe_finish_job delegates to ACCScore."""
-    monkeypatch.setenv("ACC_MINIO_ENDPOINT", "x")
-    monkeypatch.setenv("ACC_MINIO_ACCESS_KEY", "x")
-    monkeypatch.setenv("ACC_MINIO_SECRET_KEY", "x")
-    monkeypatch.setenv("ACC_DB_URL", "sqlite://")
-    from accscore.db import jobs as jobs_mod
+def test_maybe_finish_job_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """maybe_finish_job uses secondary path when primary fails."""
 
-    def stub(job_id: str) -> bool:
-        assert job_id == "job-1"
+    def stub(job_id: str) -> bool:  # noqa: ARG001
         return True
 
-    monkeypatch.setattr(jobs_mod, "maybe_finish_job", stub, raising=False)
+    _patch_resolve(
+        monkeypatch,
+        {
+            "accscore.db.jobs.maybe_finish_job": RuntimeError(),
+            "accscore.db.maybe_finish_job": stub,
+        },
+    )
     repo = DefaultRepo()
     assert repo.maybe_finish_job("job-1") is True


### PR DESCRIPTION
## Summary
- add wiring tests for DefaultRepo ensuring ACCScore paths and fallbacks

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965a819e78832bb628081af6dd32e2