### PR TITLE
Add DB session helpers and engine-aware DefaultRepo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [{ name = "Your Team", email = "dev@example.com" }]
 dependencies = [
     "typer>=0.12",           # kényelmi CLI (builder/agent indítókhoz)
     "structlog>=24.1.0",     # strukturált log (opcionális, használhatod a std loggingot is)
+    "SQLAlchemy>=2.0",       # adatbázis kapcsolat
 ]
 
 [project.optional-dependencies]

--- a/src/accs_app/agents/builder.py
+++ b/src/accs_app/agents/builder.py
@@ -9,6 +9,7 @@ import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from importlib import import_module
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ def _resolve(path: str) -> Callable[..., Any]:
     if not module_path or not attr:
         raise RuntimeError(f"invalid import path: {path}")
     try:
-        module = __import__(module_path, fromlist=[attr])
+        module = import_module(module_path)
     except ModuleNotFoundError as exc:  # pragma: no cover
         raise RuntimeError(f"module not found: {module_path}") from exc
     try:

--- a/src/accs_app/db/__init__.py
+++ b/src/accs_app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database helpers for the builder application."""

--- a/src/accs_app/db/session.py
+++ b/src/accs_app/db/session.py
@@ -1,0 +1,35 @@
+"""SQLAlchemy session helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Connection, Engine
+
+
+def get_engine(dsn: str) -> Engine:
+    """Create an :class:`~sqlalchemy.engine.Engine` for ``dsn``.
+
+    Args:
+        dsn: Database connection string.
+
+    Returns:
+        New SQLAlchemy engine configured for future mode.
+    """
+    return create_engine(dsn, future=True)
+
+
+@contextmanager
+def session_scope(engine: Engine) -> Iterator[Connection]:
+    """Provide a transactional scope around a series of operations.
+
+    Args:
+        engine: SQLAlchemy engine to create a session from.
+
+    Yields:
+        An active connection within a transaction.
+    """
+    with engine.begin() as conn:
+        yield conn

--- a/tests/test_builder_repo_wiring.py
+++ b/tests/test_builder_repo_wiring.py
@@ -38,7 +38,7 @@ def test_select_due_jobs_primary(monkeypatch: pytest.MonkeyPatch) -> None:
         return [{"id": "j1"}, {"job_id": "j2"}, "j3"]
 
     _patch_resolve(monkeypatch, {"accscore.db.jobs.select_due_jobs": stub})
-    repo = DefaultRepo()
+    repo = DefaultRepo(dsn="sqlite://")
     ids = [d.job_id for d in repo.select_due_jobs(now)]
     assert ids == ["j1", "j2", "j3"]
 
@@ -57,7 +57,7 @@ def test_select_due_jobs_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
             "accscore.db.select_due_jobs": stub,
         },
     )
-    repo = DefaultRepo()
+    repo = DefaultRepo(dsn="sqlite://")
     ids = [d.job_id for d in repo.select_due_jobs(now)]
     assert ids == ["j1", "j2", "j3"]
 
@@ -75,7 +75,7 @@ def test_instantiate_job_tasks_fallback(monkeypatch: pytest.MonkeyPatch) -> None
             "accscore.db.instantiate_tasks": stub,
         },
     )
-    repo = DefaultRepo()
+    repo = DefaultRepo(dsn="sqlite://")
     assert repo.instantiate_job_tasks("job-1") == 2
 
 
@@ -90,7 +90,7 @@ def test_apply_retry_backoff_missing(
             "accscore.db.jobs.apply_retry_backoff": RuntimeError(),
         },
     )
-    repo = DefaultRepo()
+    repo = DefaultRepo(dsn="sqlite://")
     caplog.set_level(logging.INFO)
     now = datetime(2024, 1, 1, tzinfo=UTC)
     assert repo.apply_retry_backoff(now) == 0
@@ -110,5 +110,5 @@ def test_maybe_finish_job_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
             "accscore.db.maybe_finish_job": stub,
         },
     )
-    repo = DefaultRepo()
+    repo = DefaultRepo(dsn="sqlite://")
     assert repo.maybe_finish_job("job-1") is True

--- a/tests/test_builder_tick.py
+++ b/tests/test_builder_tick.py
@@ -91,8 +91,15 @@ def test_cli_once_calls_tick_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
         ran["called"] = True
         return 0
 
+    class DummyRepo:
+        def __init__(self, dsn: str | None = None) -> None:  # noqa: ARG002
+            self.dsn = dsn
+
     monkeypatch.setattr("accs_app.agents.builder.tick", fake_tick)
-    monkeypatch.setattr("sys.argv", ["accs-builder", "--once"])
+    monkeypatch.setattr("accs_app.agents.builder.DefaultRepo", DummyRepo)
+    monkeypatch.setattr(
+        "sys.argv", ["accs-builder", "--once", "--dsn", "sqlite://"]
+    )
     main()
     assert ran["called"] is True
 
@@ -124,7 +131,9 @@ def test_cli_loop_catches_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(builder.time, "sleep", fake_sleep)
     monkeypatch.setattr(builder.logger, "exception", fake_exception)
     monkeypatch.setattr(builder, "_stop", False, raising=False)
-    monkeypatch.setattr("sys.argv", ["accs-builder", "--every", "0"])
+    monkeypatch.setattr(
+        "sys.argv", ["accs-builder", "--every", "0", "--dsn", "sqlite://"]
+    )
 
     with pytest.raises(SystemExit):
         main()

--- a/tests/test_pg_integration.py
+++ b/tests/test_pg_integration.py
@@ -1,0 +1,19 @@
+"""Optional PostgreSQL integration smoke tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from accs_app.db.session import get_engine, session_scope
+
+
+def test_pg_connection() -> None:
+    """Connect to PostgreSQL if ``ACC_DB_URL`` is provided."""
+    dsn = os.environ.get("ACC_DB_URL")
+    if not dsn:
+        pytest.skip("no PG dsn")
+    engine = get_engine(dsn)
+    with session_scope(engine) as conn:
+        assert conn.exec_driver_sql("select 1").scalar() == 1

--- a/tests/test_repo_conn_injection.py
+++ b/tests/test_repo_conn_injection.py
@@ -1,0 +1,49 @@
+"""Tests for connection injection and session helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from accs_app.agents.builder import DefaultRepo
+from accs_app.db.session import get_engine, session_scope
+
+
+def test_repo_conn_injection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DefaultRepo methods inject ``conn`` when required."""
+    calls: dict[str, object] = {}
+
+    def f(_now: datetime, *, conn: object) -> list[dict[str, str]]:
+        calls["conn"] = conn
+        return [{"id": "j1"}]
+
+    def g(_job_id: str) -> int:
+        calls["g"] = True
+        return 1
+
+    mapping = {
+        "accscore.db.jobs.select_due_jobs": f,
+        "accscore.db.jobs.instantiate_job_tasks": g,
+    }
+
+    def fake_resolve(path: str) -> object:
+        return mapping[path]
+
+    monkeypatch.setattr(DefaultRepo, "_resolve", staticmethod(fake_resolve))
+
+    repo = DefaultRepo(dsn="sqlite://")
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+
+    assert [d.job_id for d in repo.select_due_jobs(now)] == ["j1"]
+    assert calls["conn"] is not None
+    assert repo.instantiate_job_tasks("job") == 1
+    assert calls["g"] is True
+
+
+def test_session_scope_smoke() -> None:
+    """session_scope opens a transaction and yields a connection."""
+    engine = get_engine("sqlite://")
+    with session_scope(engine) as conn:
+        res = conn.exec_driver_sql("select 1")
+        assert res.scalar() == 1


### PR DESCRIPTION
## Summary
- add SQLAlchemy engine/session helpers
- allow DefaultRepo to manage its own engine and inject connections
- support `--dsn` flag for builder CLI and log masked DSN

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`
- `ACC_DB_URL=sqlite:// ACC_MINIO_ENDPOINT=x ACC_MINIO_ACCESS_KEY=x ACC_MINIO_SECRET_KEY=x accs-builder --once --dsn sqlite://`


------
https://chatgpt.com/codex/tasks/task_e_689cea790f0c832b998323b4422daf00