### PR TITLE
feat: add service agent and shared DB repo base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,4 @@ packages = ["src/accs_app"]
 
 [project.scripts]
 accs-builder = "accs_app.agents.builder:main"
+accs-agent = "accs_app.agents.service:main"

--- a/src/accs_app/agents/service.py
+++ b/src/accs_app/agents/service.py
@@ -1,0 +1,309 @@
+"""Minimal service agent executing claimed tasks."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from accs_app.db.repo_base import DBRepoBase
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Task:
+    """Description of a task to be executed by a service."""
+
+    id: str
+    job_id: str
+    task_key: str
+    service: str
+    params: dict | None = None
+
+
+class Repo(Protocol):
+    """Repository facade used by :func:`run_agent` for persistence."""
+
+    def select_runnable(
+        self, service: str, limit: int, now: datetime
+    ) -> Iterable[Task]:
+        """Return runnable tasks for ``service`` ordered by job sequence."""
+
+    def claim_tasks(self, task_ids: list[str], node: str, now: datetime) -> list[str]:
+        """Attempt to claim ``task_ids`` for ``node`` and return claimed IDs."""
+
+    def mark_task_running(self, task_id: str, now: datetime) -> None:
+        """Mark a task as running."""
+
+    def append_event(
+        self,
+        task_id: str,
+        level: str,
+        type: str,
+        message: str,
+        data: dict | None = None,
+    ) -> None:
+        """Append an event entry for ``task_id``."""
+
+    def mark_task_done(self, task_id: str, results: dict | None, now: datetime) -> None:
+        """Mark ``task_id`` as successfully completed."""
+
+    def mark_task_error(
+        self,
+        task_id: str,
+        code: str,
+        message: str,
+        now: datetime,
+        data: dict | None = None,
+    ) -> None:
+        """Mark ``task_id`` failed with ``code`` and ``message``."""
+
+
+class DefaultRepo(DBRepoBase):
+    """Repository implementation resolving ACCScore helpers dynamically."""
+
+    def select_runnable(
+        self, service: str, limit: int, now: datetime
+    ) -> Iterable[Task]:
+        """Return runnable tasks for ``service``."""
+        logger.debug("select_runnable service=%s limit=%s now=%s", service, limit, now)
+        rows: Iterable[Any] | None = None
+        for path in (
+            "accscore.db.tasks.select_runnable",
+            "accscore.db.select_runnable",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                rows = self.with_conn(func, service, limit, now)
+            except TypeError:
+                return []
+            break
+        else:
+            return []
+        tasks: list[Task] = []
+        for row in rows or []:
+            if isinstance(row, Task):
+                tasks.append(row)
+                continue
+            if isinstance(row, dict):
+                tasks.append(
+                    Task(
+                        id=str(row.get("id")),
+                        job_id=str(row.get("job_id")),
+                        task_key=str(row.get("task_key")),
+                        service=str(row.get("service", service)),
+                        params=row.get("params"),
+                    )
+                )
+        return tasks
+
+    def claim_tasks(self, task_ids: list[str], node: str, now: datetime) -> list[str]:
+        """Claim ``task_ids`` for ``node`` and return the claimed IDs."""
+        logger.debug("claim_tasks ids=%s node=%s now=%s", task_ids, node, now)
+        for path in (
+            "accscore.db.tasks.claim_tasks",
+            "accscore.db.claim_tasks",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                result = self.with_conn(func, task_ids, node, now)
+            except TypeError:
+                return []
+            if result is None:
+                return []
+            return [str(r) for r in result]
+        return []
+
+    def mark_task_running(self, task_id: str, now: datetime) -> None:
+        """Mark ``task_id`` as running."""
+        for path in (
+            "accscore.db.tasks.mark_task_running",
+            "accscore.db.mark_task_running",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                self.with_conn(func, task_id, now)
+            except TypeError:
+                pass
+            return
+
+    def append_event(
+        self,
+        task_id: str,
+        level: str,
+        type: str,
+        message: str,
+        data: dict | None = None,
+    ) -> None:
+        """Append an event for ``task_id``."""
+        for path in (
+            "accscore.db.events.append_event",
+            "accscore.db.append_event",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                self.with_conn(func, task_id, level, type, message, data)
+            except TypeError:
+                pass
+            return
+
+    def mark_task_done(self, task_id: str, results: dict | None, now: datetime) -> None:
+        """Mark ``task_id`` as completed."""
+        for path in (
+            "accscore.db.tasks.mark_task_done",
+            "accscore.db.mark_task_done",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                self.with_conn(func, task_id, results, now)
+            except TypeError:
+                pass
+            return
+
+    def mark_task_error(
+        self,
+        task_id: str,
+        code: str,
+        message: str,
+        now: datetime,
+        data: dict | None = None,
+    ) -> None:
+        """Record an error for ``task_id``."""
+        for path in (
+            "accscore.db.tasks.mark_task_error",
+            "accscore.db.mark_task_error",
+        ):
+            try:
+                func = self._resolve(path)
+            except RuntimeError:
+                continue
+            try:
+                self.with_conn(func, task_id, code, message, now, data)
+            except TypeError:
+                pass
+            return
+
+
+def execute_task(task: Task) -> dict | None:
+    """Execute ``task`` and return result.
+
+    The MVP implementation merely logs the task and returns ``{"ok": True}``.
+    """
+    logger.info("execute_task task_id=%s", task.id)
+    return {"ok": True}
+
+
+def _run_once(
+    service: str,
+    node: str,
+    capacity: int,
+    dsn: str | None,
+    *,
+    repo: Repo | None = None,
+) -> None:
+    """Run a single iteration of the service agent."""
+    repo = repo or DefaultRepo(dsn=dsn)
+    now = datetime.now(UTC)
+    tasks = list(repo.select_runnable(service, capacity, now))
+    if not tasks:
+        return None
+    claimed = repo.claim_tasks([t.id for t in tasks], node, now)
+    for task in tasks:
+        if task.id not in claimed:
+            continue
+        repo.mark_task_running(task.id, now)
+        repo.append_event(
+            task.id, "info", "task.start", f"{service} start", {"node": node}
+        )
+        try:
+            result = execute_task(task)
+            repo.mark_task_done(task.id, result, datetime.now(UTC))
+            repo.append_event(task.id, "info", "task.done", f"{service} done")
+        except Exception as exc:  # pragma: no cover - defensive
+            repo.mark_task_error(task.id, "runtime_error", str(exc), datetime.now(UTC))
+            repo.append_event(task.id, "error", "task.error", str(exc))
+    return None
+
+
+def run_agent(
+    service: str,
+    node: str,
+    *,
+    capacity: int = 1,
+    every: float = 1.0,
+    dsn: str | None = None,
+) -> None:
+    """Continuously run the service agent loop."""
+    repo = DefaultRepo(dsn=dsn)
+    interval = max(0.05, every)
+    while True:
+        now = datetime.now(UTC)
+        try:
+            tasks = list(repo.select_runnable(service, capacity, now))
+            if not tasks:
+                time.sleep(interval)
+                continue
+            claimed_ids = repo.claim_tasks([t.id for t in tasks], node, now)
+            for t in tasks:
+                if t.id not in claimed_ids:
+                    continue
+                repo.mark_task_running(t.id, now)
+                repo.append_event(
+                    t.id, "info", "task.start", f"{service} start", {"node": node}
+                )
+                try:
+                    result = execute_task(t)
+                    repo.mark_task_done(t.id, result, datetime.now(UTC))
+                    repo.append_event(t.id, "info", "task.done", f"{service} done")
+                except Exception as exc:  # pragma: no cover - defensive
+                    repo.mark_task_error(
+                        t.id, "runtime_error", str(exc), datetime.now(UTC)
+                    )
+                    repo.append_event(t.id, "error", "task.error", str(exc))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("service.loop.failed: %s", exc)
+            time.sleep(interval)
+
+
+def main() -> None:
+    """Command line interface for the service agent."""
+    parser = argparse.ArgumentParser("accs-agent")
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--node", required=True)
+    parser.add_argument("--capacity", type=int, default=1)
+    parser.add_argument("--every", type=float, default=1.0)
+    parser.add_argument("--dsn", default=None)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    if args.once:
+        _run_once(args.service, args.node, args.capacity, args.dsn)
+    else:
+        run_agent(
+            args.service,
+            args.node,
+            capacity=args.capacity,
+            every=args.every,
+            dsn=args.dsn,
+        )

--- a/src/accs_app/db/repo_base.py
+++ b/src/accs_app/db/repo_base.py
@@ -1,0 +1,79 @@
+"""Shared database repository helpers."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from importlib import import_module
+from typing import Any
+
+from accs_app.db.session import get_engine, session_scope
+
+
+def _resolve(path: str) -> Callable[..., Any]:
+    """Resolve a dotted ``path`` to a callable.
+
+    Args:
+        path: Dotted import path to resolve.
+
+    Returns:
+        The resolved callable.
+
+    Raises:
+        RuntimeError: If the module or attribute cannot be resolved.
+    """
+    module_path, _, attr = path.rpartition(".")
+    if not module_path or not attr:
+        raise RuntimeError(f"invalid import path: {path}")
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise RuntimeError(f"module not found: {module_path}") from exc
+    try:
+        return getattr(module, attr)
+    except AttributeError as exc:  # pragma: no cover
+        raise RuntimeError(f"attribute not found: {path}") from exc
+
+
+class DBRepoBase:
+    """Base class for repositories accessing the database.
+
+    The class initialises an SQLAlchemy engine and provides utilities to resolve
+    ACCScore helper functions and call them with optional connection injection.
+    """
+
+    _resolve = staticmethod(_resolve)
+
+    def __init__(self, dsn: str | None = None) -> None:
+        """Initialise repository with a database engine.
+
+        Args:
+            dsn: Optional database connection string. When ``None`` the
+                configuration is loaded from :class:`accscore.settings.Settings`.
+        """
+        if dsn is None:
+            from accscore.settings import Settings  # type: ignore[import-not-found]
+
+            dsn = Settings().postgres_dsn
+        self._engine = get_engine(dsn)
+
+    def _call_with_optional_conn(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        conn: Any | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Call ``func`` injecting ``conn`` if its signature expects it."""
+        sig = inspect.signature(func)
+        if "conn" in sig.parameters and conn is not None and "conn" not in kwargs:
+            kwargs["conn"] = conn
+        return func(*args, **kwargs)
+
+    def with_conn(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute ``func`` within a database session.
+
+        The connection is injected if ``func`` accepts a ``conn`` keyword.
+        """
+        with session_scope(self._engine) as conn:
+            return self._call_with_optional_conn(func, *args, conn=conn, **kwargs)

--- a/tests/test_service_agent.py
+++ b/tests/test_service_agent.py
@@ -1,0 +1,144 @@
+"""Tests for the service agent MVP."""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime  # noqa: F401
+
+import pytest
+
+from accs_app.agents import service
+from accs_app.agents.service import Task, _run_once
+
+
+class FakeRepo:
+    """In-memory repository capturing calls for assertions."""
+
+    def __init__(self) -> None:
+        self.tasks = [
+            Task(id="t1", job_id="ja", task_key="k1", service="render"),
+            Task(id="t2", job_id="jb", task_key="k1", service="render"),
+        ]
+        self.events: list[tuple[str, str]] = []
+        self.done: list[tuple[str, dict | None]] = []
+        self.errors: list[tuple[str, str]] = []
+
+    def select_runnable(self, service: str, limit: int, now: datetime) -> list[Task]:
+        """Return the predefined tasks."""
+        return list(self.tasks)
+
+    def claim_tasks(self, task_ids: list[str], node: str, now: datetime) -> list[str]:
+        """Simulate claiming only the first task ID."""
+        return [task_ids[0]]
+
+    def mark_task_running(self, task_id: str, now: datetime) -> None:
+        """Record that ``task_id`` entered running state."""
+        self.events.append((task_id, "running"))
+
+    def append_event(
+        self,
+        task_id: str,
+        level: str,
+        type: str,
+        message: str,
+        data: dict | None = None,
+    ) -> None:
+        """Record an event for ``task_id``."""
+        self.events.append((task_id, type))
+
+    def mark_task_done(self, task_id: str, results: dict | None, now: datetime) -> None:
+        """Store completion results for ``task_id``."""
+        self.done.append((task_id, results))
+
+    def mark_task_error(
+        self,
+        task_id: str,
+        code: str,
+        message: str,
+        now: datetime,
+        data: dict | None = None,
+    ) -> None:
+        """Store error information for ``task_id``."""
+        self.errors.append((task_id, message))
+
+
+def test_run_once_happy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_run_once processes a single claimed task and records events."""
+    repo = FakeRepo()
+    monkeypatch.setattr(service, "execute_task", lambda t: {"ok": True})
+
+    _run_once("render", "node-1", 1, None, repo=repo)
+
+    assert repo.done == [("t1", {"ok": True})]
+    types = [t for _, t in repo.events]
+    assert "task.start" in types and "task.done" in types
+
+
+def test_run_once_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task execution errors are recorded via mark_task_error and events."""
+    repo = FakeRepo()
+
+    def boom(_t: Task) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service, "execute_task", boom)
+
+    _run_once("render", "node-1", 1, None, repo=repo)
+
+    assert repo.errors and repo.errors[0][0] == "t1"
+    types = [t for _, t in repo.events]
+    assert "task.error" in types
+
+
+def test_ordered_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tasks are processed in the order they are claimed."""
+    repo = FakeRepo()
+    repo.tasks = [
+        Task(id="jobA_task1", job_id="jobA", task_key="k1", service="render"),
+        Task(id="jobB_task1", job_id="jobB", task_key="k1", service="render"),
+    ]
+    monkeypatch.setattr(service, "execute_task", lambda t: {"ok": True})
+
+    _run_once("render", "node-1", 1, None, repo=repo)
+
+    assert repo.done[0][0] == "jobA_task1"
+
+
+def test_cli_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI with --once invokes _run_once."""
+    called: dict[str, tuple[str, ...]] = {}
+
+    def fail(*_a: object, **_k: object) -> None:
+        raise RuntimeError("run_agent called")
+
+    monkeypatch.setattr(service, "run_agent", fail)
+
+    def fake_run_once(
+        service_name: str,
+        node: str,
+        capacity: int,
+        dsn: str | None,
+        *,
+        repo: object | None = None,
+    ) -> None:
+        called["args"] = (service_name, node, str(capacity), dsn or "")
+
+    monkeypatch.setattr(service, "_run_once", fake_run_once)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "accs-agent",
+            "--service",
+            "render",
+            "--node",
+            "n1",
+            "--once",
+            "--dsn",
+            "sqlite://",
+        ],
+    )
+
+    service.main()
+
+    assert called["args"][0] == "render" and called["args"][1] == "n1"


### PR DESCRIPTION
## Summary
- implement service agent with task DTO, repo wiring and CLI entrypoint
- extract DBRepoBase for shared connection and resolver helpers
- use DBRepoBase in builder repo and add tests for service agent

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e47c2f154832bb826b2a3f488177e